### PR TITLE
Don't throw error on empty files

### DIFF
--- a/e2e/index.js
+++ b/e2e/index.js
@@ -11,6 +11,7 @@ const files = [
   [nodeModulesPath, 'foundation-sites', 'scss', '_global.scss'],
   [stylePath, '_settings.scss'],
   [stylePath, '_globals.scss'],
+  [stylePath, '_override.scss'],
 ].map(paths => path.join.apply(path, paths))
 
 const includePaths = [

--- a/e2e/style/_override.scss
+++ b/e2e/style/_override.scss
@@ -1,0 +1,3 @@
+// Variables may be overridden here.
+// This file is left empty intentionally.
+

--- a/src/parser/__tests__/extractDeclarations.js
+++ b/src/parser/__tests__/extractDeclarations.js
@@ -42,12 +42,12 @@ describe('Parser', () => {
       ])
     })
 
-    it('throws if there are no declarations', () => {
+    it('returns empty list if there are no declarations', () => {
       const text = '.c {\n' +
         '  $inner-decl: "inner";\n' +
         '}'
 
-      expect(() => extractDeclarations(text)).toThrowError(/Error while extracting declaration:\n\t/)
+      expect(extractDeclarations(text)).toEqual([])
     })
   })
 })

--- a/src/parser/extractDeclarations.js
+++ b/src/parser/extractDeclarations.js
@@ -6,7 +6,7 @@ export default (content: string) => {
   const matches = content.match(new RegExp(globalVariableSyntax, 'g'))
 
   if (!matches) {
-    return [];
+    return []
   }
 
   return matches

--- a/src/parser/extractDeclarations.js
+++ b/src/parser/extractDeclarations.js
@@ -6,7 +6,7 @@ export default (content: string) => {
   const matches = content.match(new RegExp(globalVariableSyntax, 'g'))
 
   if (!matches) {
-    throw new Error(`Error while extracting declaration:\n\t${content}`)
+    return [];
   }
 
   return matches


### PR DESCRIPTION
This change stops an error being thrown when one of the SCSS files doesn't contain any variable declarations. Addresses #2.